### PR TITLE
關於在linux 下無法送字的問題/Tab or [] 無法換頁

### DIFF
--- a/taigi_pojhanlo_sujiphoat/taigi_pojhanlo.schema.yaml
+++ b/taigi_pojhanlo_sujiphoat/taigi_pojhanlo.schema.yaml
@@ -112,10 +112,22 @@ punctuator: # 設定標點符號表
 
 
 key_binder:
+  import_preset: default
   bindings:
     # 候選字換頁ê hotkey
-    - { when: composing, accept: Tab, send: Page_Down }
-    - { when: composing, accept: Shift+Tab, send: Page_Up }
-    - { when: composing, accept: bracketright, send: Page_Down }
-    - { when: composing, accept: bracketleft, send: Page_Up }
+    -  when: composing
+       accept: Tab
+       send: Page_Down
+
+    -  when: composing
+       accept: Shift+Tab
+       send: Page_Up
+
+    -  when: composing
+       accept: bracketright
+       send: Page_Down
+    
+    -  when: composing
+       accept: bracketleft
+       send: Page_Up
         

--- a/taigi_pojhanlo_sujiphoat/taigi_pojhanlo.schema.yaml
+++ b/taigi_pojhanlo_sujiphoat/taigi_pojhanlo.schema.yaml
@@ -39,8 +39,8 @@ engine: # 輸入法iăn-jín
     - punctuator    # 標點符號處理器，將孤1-ê字元key直接對應到標點符號a̍h是文字
     - selector  # 候選字選字、換頁
     - navigator # sòa beh插入去ê位置
-#    - express_editor    # 編輯器，處理phah空格、enter key ē送去螢幕，處理bá-kuh key。
-    - fluid_editor    # 句式編輯器，用來做空格斷詞、用enter key送去螢幕ê【注音】、【語句流】等等輸入方案，替換 express_editor。Mā ē-sái寫做 fluency_editor。
+    - express_editor    # 編輯器，處理phah空格、enter key ē送去螢幕，處理bá-kuh key。
+ #   - fluid_editor    # 句式編輯器，用來做空格斷詞、用enter key送去螢幕ê【注音】、【語句流】等等輸入方案，替換 express_editor。Mā ē-sái寫做 fluency_editor。
   
   segmentors:   # Hun段標記處理
     - ascii_segmentor   # 標記英文段落（譬喻tī英文模式），字母直接送去螢幕。
@@ -123,5 +123,5 @@ key_binder:
 editor:
   bindings:
 #    Return: commit_composition # 使用 express_editor ê時phah開
-    space: commit_composition # 使用 fluency_editor ê時phah開
-    Shift+Return: commit_raw_input # 上屏原始輸入
+#    space: commit_composition # 使用 fluency_editor ê時phah開
+#    Shift+Return: commit_raw_input # 上屏原始輸入

--- a/taigi_pojhanlo_sujiphoat/taigi_pojhanlo.schema.yaml
+++ b/taigi_pojhanlo_sujiphoat/taigi_pojhanlo.schema.yaml
@@ -40,7 +40,7 @@ engine: # 輸入法iăn-jín
     - selector  # 候選字選字、換頁
     - navigator # sòa beh插入去ê位置
     - express_editor    # 編輯器，處理phah空格、enter key ē送去螢幕，處理bá-kuh key。
- #   - fluid_editor    # 句式編輯器，用來做空格斷詞、用enter key送去螢幕ê【注音】、【語句流】等等輸入方案，替換 express_editor。Mā ē-sái寫做 fluency_editor。
+#   - fluid_editor    # 句式編輯器，用來做空格斷詞、用enter key送去螢幕ê【注音】、【語句流】等等輸入方案，替換 express_editor。Mā ē-sái寫做 fluency_editor。
   
   segmentors:   # Hun段標記處理
     - ascii_segmentor   # 標記英文段落（譬喻tī英文模式），字母直接送去螢幕。
@@ -119,9 +119,3 @@ key_binder:
     - { when: composing, accept: bracketright, send: Page_Down }
     - { when: composing, accept: bracketleft, send: Page_Up }
         
-        
-editor:
-  bindings:
-#    Return: commit_composition # 使用 express_editor ê時phah開
-#    space: commit_composition # 使用 fluency_editor ê時phah開
-#    Shift+Return: commit_raw_input # 上屏原始輸入


### PR DESCRIPTION
1. 我讀了一下rime的documentation，似乎是
 ```
- express_editor    # 編輯器，處理phah空格、enter key ē送去螢幕，處理bá-kuh key。
#  - fluid_editor    # 句式編輯器，用來做空格斷詞、用enter key送去螢幕ê【注音】、【語句流】等等輸入方案，替換 express_editor。Mā ē-sái寫做 fluency_editor. 
```

這個地方有問題。改成用express_editor，就可以空白鍵送字。
其他使用上並沒有什麼特別的問題，數字鍵仍然可以選發音。
查到比較多關於express_editor的資料

2. 原本的Tab, [, ] 似乎無法換頁，改成這樣寫法的yaml，就可以換頁了。



